### PR TITLE
fix: update year to 2026

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ name: {name}
 description: {description}
 metadata:
   author: Anthony Fu
-  version: "2025.1.1"
+  version: "2026.1.1"
   source: Generated from {source-url}, scripts located at https://github.com/antfu/skills
 ---
 

--- a/skills/nuxt/GENERATION.md
+++ b/skills/nuxt/GENERATION.md
@@ -2,4 +2,4 @@
 
 - **Source:** `sources/nuxt`
 - **Git SHA:** `c9fed804b9bef362276033b03ca43730c6efa7dc`
-- **Generated:** 2025-01-28
+- **Generated:** 2026-01-28

--- a/skills/nuxt/SKILL.md
+++ b/skills/nuxt/SKILL.md
@@ -3,7 +3,7 @@ name: nuxt
 description: Nuxt is a Vue.js framework for building full-stack web applications with SSR, auto-imports, file-based routing, and hybrid rendering
 metadata:
   author: Anthony Fu
-  version: "2025.1.28"
+  version: "2026.1.28"
   source: Generated from https://github.com/nuxt/nuxt, scripts located at https://github.com/antfu/skills
 ---
 

--- a/skills/pinia/GENERATION.md
+++ b/skills/pinia/GENERATION.md
@@ -2,4 +2,4 @@
 
 - **Source:** `sources/pinia`
 - **Git SHA:** `55dbfc5c20d4461748996aa74d8c0913e89fb98e`
-- **Generated:** 2025-01-28
+- **Generated:** 2026-01-28

--- a/skills/pinia/SKILL.md
+++ b/skills/pinia/SKILL.md
@@ -3,7 +3,7 @@ name: pinia
 description: The intuitive store for Vue - type-safe, extensible, and modular state management
 metadata:
   author: Anthony Fu
-  version: "2025.1.28"
+  version: "2026.1.28"
   source: Generated from https://github.com/vuejs/pinia, scripts located at https://github.com/antfu/skills
 ---
 
@@ -11,7 +11,7 @@ metadata:
 
 Pinia is the official state management library for Vue, designed to be intuitive and type-safe. It supports both Options API and Composition API styles, with first-class TypeScript support and devtools integration.
 
-> The skill is based on Pinia v3.0.4, generated at 2025-01-28.
+> The skill is based on Pinia v3.0.4, generated at 2026-01-28.
 
 ## Core References
 

--- a/skills/pnpm/GENERATION.md
+++ b/skills/pnpm/GENERATION.md
@@ -2,4 +2,4 @@
 
 - **Source:** `sources/pnpm`
 - **Git SHA:** `a1d6d5aef9d5f369fa2f0d8a54f1edbaff8b23b3`
-- **Generated:** 2025-01-28
+- **Generated:** 2026-01-28

--- a/skills/pnpm/SKILL.md
+++ b/skills/pnpm/SKILL.md
@@ -3,7 +3,7 @@ name: pnpm
 description: Fast, disk space efficient package manager for Node.js with strict dependency resolution and monorepo support
 metadata:
   author: Anthony Fu
-  version: "2025.1.28"
+  version: "2026.1.28"
   source: Generated from https://github.com/pnpm/pnpm, scripts located at https://github.com/antfu/skills
 ---
 

--- a/skills/tsdown/GENERATION.md
+++ b/skills/tsdown/GENERATION.md
@@ -2,4 +2,4 @@
 
 - **Source:** `sources/tsdown`
 - **Git SHA:** `13f1c5dfa73445728c285e7a55d921e748be1e59`
-- **Generated:** 2025-01-28
+- **Generated:** 2026-01-28

--- a/skills/tsdown/SKILL.md
+++ b/skills/tsdown/SKILL.md
@@ -3,7 +3,7 @@ name: tsdown
 description: tsdown is a fast and elegant TypeScript library bundler powered by Rolldown and Oxc
 metadata:
   author: Anthony Fu
-  version: "2025.1.28"
+  version: "2026.1.28"
   source: Generated from https://github.com/rolldown/tsdown, scripts located at https://github.com/antfu/skills
 ---
 

--- a/skills/unocss/GENERATION.md
+++ b/skills/unocss/GENERATION.md
@@ -2,4 +2,4 @@
 
 - **Source:** `sources/unocss`
 - **Git SHA:** `2f7f267d0cc0c43d44357208aabb35b049359a08`
-- **Generated:** 2025-01-28
+- **Generated:** 2026-01-28

--- a/skills/unocss/SKILL.md
+++ b/skills/unocss/SKILL.md
@@ -3,7 +3,7 @@ name: unocss
 description: Instant on-demand atomic CSS engine - fully customizable, powerful, fast, and joyful
 metadata:
   author: Anthony Fu
-  version: "2025.1.28"
+  version: "2026.1.28"
   source: Generated from https://github.com/unocss/unocss, scripts located at https://github.com/antfu/skills
 ---
 

--- a/skills/vite/GENERATION.md
+++ b/skills/vite/GENERATION.md
@@ -2,4 +2,4 @@
 
 - **Source:** `sources/vite`
 - **Git SHA:** `b40292ce6a7dbbbbac9c6dae5f126b7f44c3e1b7`
-- **Generated:** 2025-01-28
+- **Generated:** 2026-01-28

--- a/skills/vite/SKILL.md
+++ b/skills/vite/SKILL.md
@@ -3,7 +3,7 @@ name: vite
 description: Vite is a next-generation frontend build tool that provides a fast dev server with HMR and optimized production builds
 metadata:
   author: Anthony Fu
-  version: "2025.1.28"
+  version: "2026.1.28"
   source: Generated from https://github.com/vitejs/vite, scripts located at https://github.com/antfu/skills
 ---
 

--- a/skills/vitepress/GENERATION.md
+++ b/skills/vitepress/GENERATION.md
@@ -2,4 +2,4 @@
 
 - **Source:** `sources/vitepress`
 - **Git SHA:** `d4796a0373eb486766cf48e63fdf461681424d43`
-- **Generated:** 2025-01-28
+- **Generated:** 2026-01-28

--- a/skills/vitepress/SKILL.md
+++ b/skills/vitepress/SKILL.md
@@ -3,7 +3,7 @@ name: vitepress
 description: Vite & Vue powered static site generator for building fast, content-centric websites
 metadata:
   author: Anthony Fu
-  version: "2025.1.28"
+  version: "2026.1.28"
   source: Generated from https://github.com/vuejs/vitepress, scripts located at https://github.com/antfu/skills
 ---
 

--- a/skills/vitest/GENERATION.md
+++ b/skills/vitest/GENERATION.md
@@ -2,4 +2,4 @@
 
 - **Source:** `sources/vitest`
 - **Git SHA:** `4a7321e10672f00f0bb698823a381c2cc245b8f7`
-- **Generated:** 2025-01-28
+- **Generated:** 2026-01-28

--- a/skills/vitest/SKILL.md
+++ b/skills/vitest/SKILL.md
@@ -3,7 +3,7 @@ name: vitest
 description: A blazing fast unit testing framework powered by Vite
 metadata:
   author: Anthony Fu
-  version: "2025.1.28"
+  version: "2026.1.28"
   source: Generated from https://github.com/vitest-dev/vitest, scripts located at https://github.com/antfu/skills
 ---
 

--- a/skills/vue/GENERATION.md
+++ b/skills/vue/GENERATION.md
@@ -2,4 +2,4 @@
 
 - **Source:** `sources/vue`
 - **Git SHA:** `dcf363038ab2f5b4571028669cf893d084b6b207`
-- **Generated:** 2025-01-28
+- **Generated:** 2026-01-28

--- a/skills/vue/SKILL.md
+++ b/skills/vue/SKILL.md
@@ -3,7 +3,7 @@ name: vue
 description: Vue.js - The Progressive JavaScript Framework for building user interfaces
 metadata:
   author: Anthony Fu
-  version: "2025.1.28"
+  version: "2026.1.28"
   source: Generated from https://github.com/vuejs/docs, scripts located at https://github.com/antfu/skills
 ---
 


### PR DESCRIPTION
I assume 2025 was a typo there (since skills weren't a thing a year ago).

I left the copyright year as-is in LICENSE files.