### PR TITLE
refactor: simplify props definition in app-development.md

### DIFF
--- a/skills/antfu/references/app-development.md
+++ b/skills/antfu/references/app-development.md
@@ -51,9 +51,9 @@ interface Emits {
   (e: 'close'): void
 }
 
-const props = withDefaults(defineProps<Props>(), {
-  count: 0,
-})
+const {
+  count = 0
+} = defineProps<Props>()
 
 const emit = defineEmits<Emits>()
 </script>


### PR DESCRIPTION

- [x] <- Keep this line and put an `x` between the brackts.

### Description

instead of withDefaults, use Reactive Props Destructure (from 3.5+)

### Additional context

Reactive Props Destructure [Reactive Props Destructure ](url)
