### PR TITLE
fix: edit pnpm workspace config to pnpm install work.

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,8 +2,7 @@ shellEmulator: true
 
 trustPolicy: no-downgrade
 
-packages:
-  - . # TODO add for running `pnpm i` correctly for now, if it's not added, `pnpm i` will fail. Remove it when planning to add real workspace packages.
+packages: []
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving, and "WHY" -->

When I ran command `nr i` it gave me these errors.

```shell
❯ nr i
 ERROR  packages field missing or empty
For help, run: pnpm help run
```

So I add `packages` field in pnpm workspace config.

Another line adds is by save-action that solves these issues.

```
Setting "shellEmulator" has mismatch value. Expected: true, Actual: undefined.eslint[pnpm/yaml-enforce-settings](https://github.com/antfu/pnpm-workspace-utils/tree/main/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-enforce-settings.test.ts)
Setting "trustPolicy" has mismatch value. Expected: "no-downgrade", Actual: undefined.eslint[pnpm/yaml-enforce-settings](https://github.com/antfu/pnpm-workspace-utils/tree/main/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-enforce-settings.test.ts)
Expected mapping keys to be in specified order. 'onlyBuiltDependencies' should be after 'packages'.eslint[yaml/sort-keys](https://ota-meshi.github.io/eslint-plugin-yml/rules/sort-keys.html)
```

### Linked Issues

fixes #<number>

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
