### PR TITLE
feat: support custom skills path for vendor projects

### DIFF
--- a/meta.ts
+++ b/meta.ts
@@ -1,6 +1,7 @@
 export interface VendorSkillMeta {
   official?: boolean
   source: string
+  skillsPath?: string // Optional custom path to skills directory (default: 'skills')
   skills: Record<string, string> // sourceSkillName -> outputSkillName
 }
 

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -64,6 +64,7 @@ interface Project {
 
 interface VendorConfig {
   source: string
+  skillsPath?: string // Optional custom path to skills directory (default: 'skills')
   skills: Record<string, string> // sourceSkillName -> outputSkillName
 }
 
@@ -190,7 +191,8 @@ async function syncSubmodules() {
   for (const [vendorName, config] of Object.entries(vendors)) {
     const vendorConfig = config as VendorConfig
     const vendorPath = join(root, 'vendor', vendorName)
-    const vendorSkillsPath = join(vendorPath, 'skills')
+    const skillsBasePath = vendorConfig.skillsPath || 'skills'
+    const vendorSkillsPath = join(vendorPath, skillsBasePath)
 
     if (!existsSync(vendorPath)) {
       p.log.warn(`Vendor submodule not found: ${vendorName}. Run init first.`)
@@ -198,7 +200,7 @@ async function syncSubmodules() {
     }
 
     if (!existsSync(vendorSkillsPath)) {
-      p.log.warn(`No skills directory in vendor/${vendorName}/skills/`)
+      p.log.warn(`No skills directory in vendor/${vendorName}/${skillsBasePath}/`)
       continue
     }
 
@@ -255,7 +257,7 @@ async function syncSubmodules() {
 
       const syncContent = `# Sync Info
 
-- **Source:** \`vendor/${vendorName}/skills/${sourceSkillName}\`
+- **Source:** \`vendor/${vendorName}/${skillsBasePath}/${sourceSkillName}\`
 - **Git SHA:** \`${sha}\`
 - **Synced:** ${date}
 `


### PR DESCRIPTION
## Summary

Add optional `skillsPath` configuration to `VendorSkillMeta` interface to support vendor projects that store skills in non-standard directory paths.

## Motivation

Some vendor projects (like [ui-ux-pro-max](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)) store their skills in custom paths such as `.claude/skills` instead of the default `skills/` directory. 

Currently, the sync script hardcodes the `skills/` path, causing sync failures for these projects with the warning:
```
No skills directory in vendor/{name}/skills/
```

## Changes

- **`meta.ts`**: Add optional `skillsPath?: string` field to `VendorSkillMeta` interface
- **`scripts/cli.ts`**: 
  - Add `skillsPath` to `VendorConfig` interface
  - Update `syncSubmodules()` to use `vendorConfig.skillsPath || 'skills'` with fallback
  - Update SYNC.md generation to reflect the actual source path

## Example Usage

```typescript
export const vendors: Record<string, VendorSkillMeta> = {
  'ui-ux-pro-max': {
    source: 'https://github.com/nextlevelbuilder/ui-ux-pro-max-skill',
    skillsPath: '.claude/skills', // Custom path
    skills: {
      'ui-ux-pro-max': 'ui-ux-pro-max',
    },
  },
}
```

## Backward Compatibility

✅ Fully backward compatible - existing vendors without `skillsPath` continue to use the default `'skills'` directory.

## Test Plan

- [x] Tested with existing vendors (vueuse, slidev, etc.) - works as before
- [x] Tested with custom path (`.claude/skills`) - successfully syncs from non-standard paths
- [x] Verified SYNC.md reflects correct source path