### PR TITLE
fix: update stale version references in skill metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Generate [Agent Skills](https://agentskills.io/home) from project documentation.
 
-PLEASE STRICTLY FOLLOW THE BEST PRACTICES FOR SKILL: https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+PLEASE STRICTLY FOLLOW THE BEST PRACTICES FOR SKILL: https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices
 
 - Focus on agents capabilities and practical usage patterns.
 - Ignore user-facing guides, introductions, get-started, install guides, etc.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Learn more about the CLI usage at [skills](https://github.com/vercel-labs/skills
 
 ## Skills
 
-This collection is aim to be a one-stop collection of you are mainly working on Vite/Nuxt. It includes skills from different sources with different scopes.
+This collection is aims to be a one-stop collection if you are mainly working on Vite/Nuxt. It includes skills from different sources with different scopes.
 
 ### Hand-maintained Skills
 

--- a/skills/nuxt/SKILL.md
+++ b/skills/nuxt/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 Nuxt is a full-stack Vue framework that provides server-side rendering, file-based routing, auto-imports, and a powerful module system. It uses Nitro as its server engine for universal deployment across Node.js, serverless, and edge platforms.
 
-> The skill is based on Nuxt 3.x, generated at 2026-01-28.
+> The skill is based on Nuxt 4.x, generated at 2026-01-28.
 
 ## Core
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackets.

### Description

Update outdated version numbers in SKILL.md files.

- `skills/nuxt/SKILL.md`: Nuxt 3.x → 4.x

Closes #18

<!-- e.g. is there anything you'd like reviewers to focus on? -->
